### PR TITLE
fix: check framebuffer status before present

### DIFF
--- a/src/webview.rs
+++ b/src/webview.rs
@@ -113,7 +113,6 @@ impl WebView {
                 gl::NEAREST,
             );
 
-            servo.present();
             debug_assert_eq!(
                 (
                     self.webrender_gl.get_error(),
@@ -121,6 +120,8 @@ impl WebView {
                 ),
                 (gl::NO_ERROR, gl::FRAMEBUFFER_COMPLETE)
             );
+
+            servo.present();
         }
     }
 


### PR DESCRIPTION
Should check framebuffer before `present()`, otherwise the buffer will be cleaned after present and always falls into assert.